### PR TITLE
search-fix

### DIFF
--- a/src/js/search/index.js
+++ b/src/js/search/index.js
@@ -44,6 +44,8 @@ async function inSearchNews(e) {
     scrollToTop();
     newSearchToNextPage();
     refs.searchForm.reset();
+    refs.paginationCtr.classList.remove('is-hidden');
+    refs.errorCtr.classList.add('is-hidden');
   }
 }
 


### PR DESCRIPTION
пофіксив, тепер якщо після невдалого пошуку будуть знайдені статті (без перезавантаження сторінки), тоді пагінація з'являється, а заглушка зникає